### PR TITLE
Add Markstream to AI & LLM Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,7 @@ Essential libraries and tools for building modern React applications.
 *Integrate language models and run ML inference directly in your React app.*
 
 - **[Vercel AI SDK](https://sdk.vercel.ai/)**: The AI Toolkit for TypeScript. Build AI-powered products with React streaming UI and LLM integrations.
+- **[Markstream](https://markstream.simonhe.me/)**: Open-source streaming Markdown renderer for React AI chat interfaces, with incomplete-token handling, Mermaid, KaTeX, syntax highlighting, safe HTML, SSR, and React 18/19 support.
 - **[LangChain.js](https://js.langchain.com/)**: A framework for developing applications powered by language models in JavaScript and TypeScript.
 - **[OpenAI Node SDK](https://github.com/openai/openai-node)**: Official OpenAI SDK for TypeScript/JavaScript to integrate GPT models into your React applications.
 - **[Anthropic SDK](https://github.com/anthropics/anthropic-sdk-typescript)**: Official Anthropic TypeScript SDK for integrating Claude AI into your React applications.


### PR DESCRIPTION
Hi, thanks for curating React Toolkit.

This adds [Markstream](https://github.com/Simon-He95/markstream-vue) to the `AI & LLM Integration` section. It is an MIT-licensed streaming Markdown renderer with a dedicated React package for AI chat interfaces. It handles incomplete Markdown tokens and supports Mermaid, KaTeX, syntax highlighting, safe HTML, SSR, React 18/19, and Next.js.

I placed it next to the Vercel AI SDK because both are focused on streaming AI interfaces. Thanks for considering it.